### PR TITLE
Coord start and stop worker processes

### DIFF
--- a/bagel/worker_start.sh
+++ b/bagel/worker_start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+./bin/worker "$1" | tee workerp"$1".log

--- a/bagel/worker_stop.sh
+++ b/bagel/worker_stop.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+pid=$(ps aux | grep "./bin/worker $1" | grep -v grep | awk -F' ' '{print $2}')
+echo "Coord killing process ${pid}"
+kill "${pid}"
+echo "Coord killed process ${pid}"


### PR DESCRIPTION
- Add an external endpoint for coord to programmatically start and stop worker processes
  - POST http://localhost:9000/api/worker starts a new worker (worker with the smallest available id)
  - DELETE http://localhost:9000/api/worker/{id} stops the given worker id
- Add bearer token authentication 