### PR TITLE
Integrate worker processes with failover

### DIFF
--- a/bagel/worker_stop.sh
+++ b/bagel/worker_stop.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 pid=$(ps aux | grep "./bin/worker $1" | grep -v grep | awk -F' ' '{print $2}')
-echo "Coord killing process ${pid}"
-kill "${pid}"
-echo "Coord killed process ${pid}"
+if [ ! -z "${pid}" ]
+then
+  echo "Coord killing process ${pid}"
+  kill "${pid}"
+  echo "Coord killed process ${pid}"
+fi


### PR DESCRIPTION
- Coord starts workers by /POST, terminates workers by /DELETE {workerId}
- Terminating coord terminates the remaining worker processes #35 
- Terminating and restarting a worker waits for the monitor routine to detect the failure before coord proceeds with the restart #36  